### PR TITLE
#2 allow exclude files from search

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,17 @@
   ],
   "main": "./out/extension",
   "contributes": {
+    "configuration": {
+      "type": "object",
+      "title": "TSQuery extension configuration",
+      "properties": {
+        "tsquery.exclude": {
+          "description": "Configure glob patterns for excluding files and folders in searches",
+          "type": "array",
+          "default": ["**/node_modules/*/**"]
+        }
+      }
+    },
     "commands": [
       {
         "command": "extension.astQueryFile",
@@ -79,6 +90,7 @@
     "test": "npm run compile && node ./node_modules/vscode/bin/test"
   },
   "devDependencies": {
+    "@types/minimatch": "^3.0.3",
     "@types/mocha": "^2.2.42",
     "@types/node": "^7.0.43",
     "husky": "^0.14.3",
@@ -90,6 +102,7 @@
   },
   "dependencies": {
     "@phenomnomnominal/tsquery": "^1.0.0",
+    "minimatch": "^3.0.4",
     "typewiz-core": "^1.0.2",
     "util.promisify": "^1.0.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import { tsquery } from '@phenomnomnominal/tsquery';
 import { getProgram } from 'typewiz-core';
 import { createCompilerHost, Node, SyntaxKind } from 'typescript';
-import { getNodeAtFileOffset, isSupportedLanguage } from './utils';
+import { getNodeAtFileOffset, isSupportedLanguage, filterExcludedFiles } from './utils';
 import { ASTViewProvider } from './astViewProvider';
 
 interface IResult extends vscode.QuickPickItem {
@@ -170,8 +170,8 @@ async function astCustomQueryWorkspace(astQuery?: string) {
     }
 
     const matches: Node[][] = [];
-    for (let source of program.getSourceFiles()) {
-      const nodes = tsquery(source, astQuery);
+    for (const file of filterExcludedFiles(program.getSourceFiles())) {
+      const nodes = tsquery(file, astQuery);
       if (nodes.length) {
         matches.push(nodes);
       }
@@ -203,7 +203,7 @@ export function activate(context: vscode.ExtensionContext) {
   const astViewProvider = new ASTViewProvider();
   const astTreeView = vscode.window.createTreeView('astView', { treeDataProvider: astViewProvider });
   astViewProvider.setTreeView(astTreeView);
-  
+
   context.subscriptions.push(
     ...[
       astTreeView,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,6 @@
 import * as ts from 'typescript';
+import * as vscode from 'vscode';
+import * as minimatch from 'minimatch';
 
 export function getNodeAtFileOffset(node: ts.Node, offset: number) {
   let result = null as ts.Node | null;
@@ -16,4 +18,13 @@ export const supportedLanguageIds = ['javascript', 'javascriptreact', 'typescrip
 
 export function isSupportedLanguage(langId: string) {
   return supportedLanguageIds.indexOf(langId) >= 0;
+}
+
+export function filterExcludedFiles(files: ReadonlyArray<ts.SourceFile>) {
+  const excludedPatterns = vscode.workspace.getConfiguration('tsquery').get('exclude') as Array<string>;
+  let filteredFiles = files;
+  for (const pattern of excludedPatterns) {
+    filteredFiles = files.filter(({ fileName }) => !minimatch(fileName, pattern, { dot: true }));
+  }
+  return filteredFiles;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,6 +22,10 @@
   dependencies:
     esquery "^1.0.1"
 
+"@types/minimatch@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
+
 "@types/mocha@^2.2.42":
   version "2.2.48"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.48.tgz#3523b126a0b049482e1c3c11877460f76622ffab"


### PR DESCRIPTION
Added configuration propery tsquery.excluded that contains the glob patterns array that excluded in search.
By default added `**/node_modules/*/**` pattern to exclude node_modules.
The pattern matching uses external dependency minimatch.